### PR TITLE
Add xfr_hotpatch_v2, fixes notifies to secondaries with private IPs

### DIFF
--- a/utils/xfr_hotpatch_v2/README.md
+++ b/utils/xfr_hotpatch_v2/README.md
@@ -1,0 +1,14 @@
+# xfr private (RFC1918) space fix
+## problem:
+the xfrd server by default does not allow notifies to be sent to any secondary servers
+in private ip ranges.  additionally, a missing configuration option in xfrd.ini was
+preventing any notifies from being sent.
+
+## solution:
+- patch the xfr daemon to no longer block private ip addresses.
+- update ansible playbook to add outbound\_network\_interface to xfrd.ini
+
+## usage
+- copy hotpatch.sh and the patch file to the host os. make sure they are both in the same directory.
+- `chmod +x hotpatch.sh`
+- `./hotpatch.sh`

--- a/utils/xfr_hotpatch_v2/fix-notify-private-1.1.1.patch
+++ b/utils/xfr_hotpatch_v2/fix-notify-private-1.1.1.patch
@@ -1,0 +1,38 @@
+diff --git a/xfrd/xfr_notify_sender.py b/xfrd/xfr_notify_sender.py
+index bfb8c2f96..2c8f78e9d 100644
+--- a/xfrd/xfr_notify_sender.py
++++ b/xfrd/xfr_notify_sender.py
+@@ -12,8 +12,8 @@ class xfr_notify_sender(object):
+     Sends NOTIFY messages to secondaries for updated zones.
+     '''
+ 
+-    def __init__(self, network, notify_delay, interface=""):
+-        self._network = network
++    def __init__(self, allow_private, notify_delay, interface=""):
++        self._allow_private = allow_private
+         self._notify_delay = notify_delay
+         self._notify_q = {}  # deferreds to send notifies to secondaries
+         self._interface = interface
+@@ -73,7 +73,7 @@ class xfr_notify_sender(object):
+                 continue
+ 
+             # ignore if ip is private and we are no the global network
+-            if is_ipv4_private(secondary.get('ip')) and self._network == 0:
++            if not self._allow_private and is_ipv4_private(secondary.get('ip')):
+                 continue
+ 
+             LOG.warn("Sending notify for %s to %s:%d for serial %d", zone['zone'], secondary['ip'], secondary['port'], zone['record'][2])
+diff --git a/xfrd/xfrd.py b/xfrd/xfrd.py
+index 336aaf5fd..c05cb2bba 100755
+--- a/xfrd/xfrd.py
++++ b/xfrd/xfrd.py
+@@ -82,7 +82,8 @@ class xfrd_service(app_service):
+         network = int(self._config.get('server', 'networkid'))
+         notify_delay = int(self._config.get('xfrd', 'notify_delay'))
+         interface = self._config.get('xfrd', 'outbound_network_interface')
+-        self._notify_sender = xfr_notify_sender(network, notify_delay, interface)
++        allow_private = self._standalone or network != 0
++        self._notify_sender = xfr_notify_sender(allow_private, notify_delay, interface)
+ 
+     def _stop_notify_sender(self):
+         if self._notify_sender:

--- a/utils/xfr_hotpatch_v2/hotpatch.sh
+++ b/utils/xfr_hotpatch_v2/hotpatch.sh
@@ -1,0 +1,8 @@
+#!/bin/bash
+set -ex
+XFR_ID=$(docker ps -q --filter "name=xfr")
+
+docker cp fix-notify-private-1.1.1.patch $XFR_ID:/bin
+docker exec -t $XFR_ID sh -c "patch -d /ns1-images/xfrd/opt/nsone/xfrd -p2 < /bin/fix-notify-private-1.1.1.patch"
+docker exec -t $XFR_ID sh -c "echo \"outbound_network_interface = 0.0.0.0\" >> /ansible/playbooks/roles/ns1_ini/templates/sections/xfrd.ini.j2"
+docker restart $XFR_ID


### PR DESCRIPTION
New script and related patch file to correct two xfr issues in TAG 1.1.1:
 - xfrd doesn't send notifies to private IPs
 - xfrd was failing to send notifies due to missing configuration option in xfrd.ini