### PR TITLE
Add xfr_hotpatch_v3 to enable debugging.  Rolls up v1 and v2.

### DIFF
--- a/utils/xfr_hotpatch_v3/README.md
+++ b/utils/xfr_hotpatch_v3/README.md
@@ -1,0 +1,33 @@
+# add additional debugging to xfr notify logic
+## problem:
+the xfr container applies several iterations of logic to determine if a notify should
+be sent.  however, no logging is performed, which makes troubleshooting difficult.  
+
+## solution: 
+this patch adds additional logging to the notify process, allowing us to 
+troubleshoot situations where notifies are not sent.
+
+## usage
+**note:** this patch must be applied against a clean xfr container running
+the 1.1.1 tag.  the patch will fail cleanly and make no changes if it detects
+the xfr container has previous patches or modifications applied.  to undo any
+past changes, do the following (adjusted as appropriate for your environment, replacing privatedns with your project name):
+
+- stop and remove the xfr container
+
+  `docker stop privatedns_xfr_1`
+  `docker image rm privatedns_xfr_1`
+
+- remove the xfr volume
+
+  `docker rm privatedns_ns1xfr`
+
+- use docker-compose to bring up a fresh xfr container
+
+  `TAG=1.1.1 docker-compose -p privatedns up -d`
+
+once a clean xfr container is running, the patch can be applied as follows:
+
+- copy hotpatch.sh and the patch file to the host os. make sure they are both in the same directory.
+- `chmod +x hotpatch.sh`
+- `./hotpatch.sh`

--- a/utils/xfr_hotpatch_v3/README.md
+++ b/utils/xfr_hotpatch_v3/README.md
@@ -15,16 +15,16 @@ past changes, do the following (adjusted as appropriate for your environment, re
 
 - stop and remove the xfr container
 
-  `docker stop privatedns_xfr_1`
-  `docker image rm privatedns_xfr_1`
+  - `docker stop privatedns_xfr_1`
+  - `docker container rm privatedns_xfr_1`
 
 - remove the xfr volume
 
-  `docker rm privatedns_ns1xfr`
+  - `docker volume rm privatedns_ns1xfr`
 
 - use docker-compose to bring up a fresh xfr container
 
-  `TAG=1.1.1 docker-compose -p privatedns up -d`
+  - `TAG=1.1.1 docker-compose -p privatedns up -d`
 
 once a clean xfr container is running, the patch can be applied as follows:
 

--- a/utils/xfr_hotpatch_v3/hotpatch.sh
+++ b/utils/xfr_hotpatch_v3/hotpatch.sh
@@ -1,0 +1,16 @@
+#!/bin/bash
+set -ex
+XFR_ID=$(docker ps -q --filter "name=xfr")
+
+# Make sure we are patching a clean 1.1.1:
+
+xfrd_md5=`docker exec -t $XFR_ID md5sum /ns1-images/xfrd/opt/nsone/xfrd/xfrd.py |awk '{ print $1; }'`
+notify_md5=`docker exec -t $XFR_ID md5sum /ns1-images/xfrd/opt/nsone/xfrd/xfr_notify_sender.py | awk '{ print $1; }'`
+if [ $xfrd_md5 != "0fbaa34dca0f31f1e0e7ef95248ec30f" ] || [ $notify_md5 != "4ba83d63569748ee811fded401cc4fdd" ]; then
+	echo "!!! Unable to continue -- xfr container does not appear to be a clean 1.1.1"
+	exit 1
+fi
+
+docker cp xfrd-debug.patch $XFR_ID:/bin
+docker exec -t $XFR_ID sh -c "patch -d /ns1-images/xfrd/opt/nsone/xfrd -p2 < /bin/xfrd-debug.patch"
+docker restart $XFR_ID

--- a/utils/xfr_hotpatch_v3/xfrd-debug.patch
+++ b/utils/xfr_hotpatch_v3/xfrd-debug.patch
@@ -1,0 +1,193 @@
+diff --git a/xfrd/xfr_inbound.py b/xfrd/xfr_inbound.py
+index 291042422..7ed87abf1 100644
+--- a/xfrd/xfr_inbound.py
++++ b/xfrd/xfr_inbound.py
+@@ -51,7 +51,11 @@ class xfr_inbound(object):
+         our XFR job; and if primary, send NOTIFY to appropriate
+         servers.'''
+ 
++        LOG.info("NOTIFY-TRACE: _handle_zone_update(type='%s', updates)", type)
++
+         for utype, config in updates:
++            LOG.info("NOTIFY-TRACE: utype=%s", utype)
++
+             # we ignore everything but 'soa' updates where secondary
+             # config details are different than what we have
+             if utype == 'soa':
+@@ -60,6 +64,7 @@ class xfr_inbound(object):
+ 
+                 # process changes
+                 zone = config['zone']
++                LOG.info("NOTIFY-TRACE: zone=%s", zone)
+                 if type == 'create_zone':
+                     self._create_zone_cb(zone, config)
+                 elif type == 'update' or type == 'config':
+@@ -75,6 +80,8 @@ class xfr_inbound(object):
+ 
+         LOG.debug("received inbound, network %d, message %s",
+                   self._network, repr(msg))
++        LOG.info("NOTIFY-TRACE: received inbound, network %d, message %s",
++                  self._network, repr(msg))
+ 
+         # first convert from json to python native and validate this
+         # is a valid inbound update like {'type':xxx, 'payload':yyy}
+diff --git a/xfrd/xfr_notify_sender.py b/xfrd/xfr_notify_sender.py
+index bfb8c2f96..8b5573b9c 100644
+--- a/xfrd/xfr_notify_sender.py
++++ b/xfrd/xfr_notify_sender.py
+@@ -12,8 +12,18 @@ class xfr_notify_sender(object):
+     Sends NOTIFY messages to secondaries for updated zones.
+     '''
+ 
+-    def __init__(self, network, notify_delay, interface=""):
+-        self._network = network
++    def __init__(self, allow_private, notify_delay, interface):
++        """
++        allow_private - boolean indicating whether we will send notify
++                        to RFC 1918 addresses
++        notify_delay - interval to wait for additional changes to zone
++                       before sending a notify to a secondary
++                       (xfrd.notify_delay in the configuration)
++        interface - interface IP that NOTIFY will use
++                    (xfrd.outbound_network_interface in the
++                    configuration)
++        """
++        self._allow_private = allow_private
+         self._notify_delay = notify_delay
+         self._notify_q = {}  # deferreds to send notifies to secondaries
+         self._interface = interface
+@@ -30,6 +40,9 @@ class xfr_notify_sender(object):
+     def _send_notify(self, notify):
+         '''Send a NOTIFY based on (ip, port, zone).'''
+ 
++        LOG.info("NOTIFY-TRACE: xfr_notify_sender._send_notify(%s)",
++                 repr(notify))
++
+         # remove from the notify queue
+         if self._notify_q[notify].active():
+             self._notify_q[notify].cancel()
+@@ -42,6 +55,8 @@ class xfr_notify_sender(object):
+             err.trap(defer.TimeoutError)
+             LOG.warning('timed out notifying %s:%d for %s', ip, port, zone)
+ 
++        LOG.info('NOTIFY-TRACE: sending NOTIFY for %s to %s:%d', zone, ip, port)
++
+         LOG.debug('sending NOTIFY for %s to %s:%d', zone, ip, port)
+ 
+         # send the NOTIFY -- don't bother waiting for the result, but
+@@ -63,17 +78,30 @@ class xfr_notify_sender(object):
+         the queue, to prevent sending a zillion NOTIFY messages when
+         there is a flurry of updates to the zone (e.g., via API).'''
+ 
++        LOG.info("NOTIFY-TRACE: xfr_notify_sender.send(zone), zone=%s", repr(zone))
++
+         # primary DNS not enabled for this zone, bail
+         if not zone.get('primary', {}).get('enabled', False):
++            LOG.info("NOTIFY-TRACE: zone not primary, no notify sent")
+             return
+ 
+         secondaries = zone['primary'].get('secondaries', [])
+         for secondary in secondaries:
++            dbg_ip = secondary.get("ip")
++            dbg_port = secondary.get("port")
++            dbg_notify = secondary.get("notify")
++            LOG.info("NOTIFY-TRACE: considering secondary %s:%s, notify:%s",
++                     dbg_ip, dbg_port, dbg_notify)
++
+             if not secondary.get('notify') or not secondary.get('port'):
++                LOG.info("NOTIFY-TRACE: skipping secondary")
+                 continue
+ 
+             # ignore if ip is private and we are no the global network
+-            if is_ipv4_private(secondary.get('ip')) and self._network == 0:
++            LOG.info("NOTIFY-TRACE: allow_private:%s is_ipv4_private():%s",
++                     self._allow_private, is_ipv4_private(secondary.get('ip')))
++            if not self._allow_private and is_ipv4_private(secondary.get('ip')):
++                LOG.info("NOTIFY-TRACE: skipping secondary on RFC 1918 address")
+                 continue
+ 
+             LOG.warn("Sending notify for %s to %s:%d for serial %d", zone['zone'], secondary['ip'], secondary['port'], zone['record'][2])
+@@ -81,6 +109,8 @@ class xfr_notify_sender(object):
+             # queue a NOTIFY to ip:port of this secondary
+             key = (secondary['ip'], int(secondary['port']), zone['zone'])
+             if key in self._notify_q:
++                LOG.info("NOTIFY-TRACE: canceling existing notify")
+                 self._notify_q[key].cancel()
++            LOG.info("NOTIFY-TRACE: sending notify in %f seconds", self._notify_delay)
+             self._notify_q[key] = reactor.callLater(
+                 self._notify_delay, self._send_notify, key)
+diff --git a/xfrd/xfrd.py b/xfrd/xfrd.py
+index 336aaf5fd..f56dd8a03 100755
+--- a/xfrd/xfrd.py
++++ b/xfrd/xfrd.py
+@@ -82,7 +82,12 @@ class xfrd_service(app_service):
+         network = int(self._config.get('server', 'networkid'))
+         notify_delay = int(self._config.get('xfrd', 'notify_delay'))
+         interface = self._config.get('xfrd', 'outbound_network_interface')
+-        self._notify_sender = xfr_notify_sender(network, notify_delay, interface)
++        # If no interface is defined use any interface when sending.
++        if interface is None:
++            LOG.info("xfrd.outbound_network_interface not set, using ''")
++            interface = ""
++        allow_private = self._standalone or network != 0
++        self._notify_sender = xfr_notify_sender(allow_private, notify_delay, interface)
+ 
+     def _stop_notify_sender(self):
+         if self._notify_sender:
+@@ -116,31 +121,55 @@ class xfrd_service(app_service):
+                 init_networks.append(int(conf['network_id']))
+ 
+         def create(zone, config):
++            LOG.info("NOTIFY-TRACE: xfrd_service.create('%s', config)", zone)
+             # We only care about secondary zones that were just created.
+             if not config.get("secondary", {}).get("enabled", False):
++                LOG.info("NOTIFY-TRACE: zone is not a secondary zone")
+                 return
+ 
+-            if self._distributor.zone_owner(zone) == instance:
++            LOG.info("NOTIFY-TRACE: zone is a secondary zone")
++
++            distributor_zone_owner = self._distributor.zone_owner(zone)
++            LOG.info("NOTIFY-TRACE: zone_owner:%s instance:%s (create)",
++                     distributor_zone_owner, instance)
++            if distributor_zone_owner == instance:
+                 self._distributor.zones = self._distributor.zones + [zone]
++                LOG.info("NOTIFY-TRACE: added zone '%s' to this instance", zone)
+ 
+         @defer.inlineCallbacks
+         def update(zone, config):
++            LOG.info("NOTIFY-TRACE: xfrd_service.update('%s', config)", zone)
+             if zone in self._manager.zones:
++                LOG.info("NOTIFY-TRACE: updated zone '%s' in this instance's manager", zone)
+                 self._manager.update_zone(zone, config)
++            else:
++                LOG.info("NOTIFY-TRACE: zone '%s' not managed by this instance's manager (update)", zone)
+ 
++            distributor_zone_owner = self._distributor.zone_owner(zone)
++            LOG.info("NOTIFY-TRACE: zone_owner:%s instance:%s (update)",
++                     distributor_zone_owner, instance)
+             if self._distributor.zone_owner(zone) == instance:
++                LOG.info("NOTIFY-TRACE: dnssec:%s primary:%s",
++                         config.get("dnssec", False),
++                         config.get("primary", {}).get("enabled", False))
+                 # with DNSSEC, the zone has to be updated first
+                 if config.get("dnssec", False) and config.get("primary", {}).get("enabled", False):
+                     ready = yield self._glue.request_update(zone)
+                 else:
+                     ready = True
+ 
++                LOG.info("NOTIFY-TRACE: ready:%s", ready)
+                 if ready:
++                    LOG.info("NOTIFY-TRACE: trying to send notify")
+                     self._notify_sender.send(config)
+ 
+         def remove(zone):
++            LOG.info("NOTIFY-TRACE: xfrd_service.update('%s', config)", zone)
+             if zone in self._manager.zones:
+                 self._manager.remove_zone(zone)
++                LOG.info("NOTIFY-TRACE: removed zone '%s' from this instance's manager", zone)
++            else:
++                LOG.info("NOTIFY-TRACE: zone '%s' not managed by this instance's manager (remove)", zone)
+ 
+         for net in init_networks:
+             self._inbound[net] = xfr_inbound(


### PR DESCRIPTION
This is primarily for Riot to enable some debugging.  It replaces v1/v2, so it must be applied against a clean 1.1.1.  Instructions in the README.md (and will be in the ticket as well)