### PR TITLE
fix to respect array

### DIFF
--- a/utils/get_privatedns/get_privatedns.sh
+++ b/utils/get_privatedns/get_privatedns.sh
@@ -40,7 +40,7 @@ get_latest_stream() {
 }
 
 get_latest_version() {
-  grep -oE '"version":"[0-9\.]+"' | grep -oE '[0-9\.]+'
+  grep -oE -m1 '"version":"[0-9\.]+"' | grep -oE -m1 '[0-9\.]+'
 }
 
 get_available_containers() {


### PR DESCRIPTION
the bash script was never aware there could be multiple active streams   this fixes it by taking advantage of the enforced ordering from API