### PR TITLE
Compose update

### DIFF
--- a/docker-compose/README.md
+++ b/docker-compose/README.md
@@ -33,7 +33,7 @@ Use to start all container images on a single host: `data`, `dns`, `core`, `xfr`
 - `DHCP_CONTAINER_NAME`: Sets the container's name; defaults to `dhcp`
 - `DIST_CONTAINER_NAME`: Sets the container's name; defaults to `dist`
 - `CORE_HOSTS`: Series of comma delimited hostnames of `core` containers; specifies upstream `core` containers; defaults to `core`
-- `DIST_OR_CORE_HOSTS`: Series of comma delimited hostnames of distribution containers e.g. dist1,dist2; defaults to `dist`
+- `DIST_HOSTS`: Series of comma delimited hostnames of distribution containers e.g. dist1,dist2; defaults to `dist`
 - `OPERATION_MODE`: `authoritative`/`recursive`; the mode of operation for this `dns` container; defaults to `authoritative`
 
 #### For example:
@@ -101,7 +101,7 @@ Used to start edge services on a single host: `dns`, `dhcp` and `dist` (distribu
 - `DHCP_CONTAINER_NAME`: Sets the container's name; defaults to `dhcp`
 - `DIST_CONTAINER_NAME`: Sets the container's name; defaults to `dist`
 - `CORE_HOSTS`: Series of comma delimited hostnames of `core` containers; specifies upstream `core` containers; defaults to `core`
-- `DIST_OR_CORE_HOSTS`: Series of comma delimited hostnames of distribution containers e.g. dist1,dist2; defaults to `dist`
+- `DIST_HOSTS`: Series of comma delimited hostnames of distribution containers e.g. dist1,dist2; defaults to `dist`
 - `OPERATION_MODE`: `authoritative`/`recursive`; the mode of operation for this `dns` container; defaults to `authoritative`
 
 #### For example:

--- a/docker-compose/control-compose.yml
+++ b/docker-compose/control-compose.yml
@@ -11,8 +11,8 @@ services:
     environment:        # keep environment lines if 2+ containers
       CONFIG_PORT: 3305 # are on the host machine
       CONTAINER_NAME: ${DATA_CONTAINER_NAME:-data}
-      # IMPORTANT!  This should only be enabled on a single data host.
-      # Uncomment the following on additional data peers.
+      # IMPORTANT!  DATA_PRIMARY should only be enabled on a single data host.
+      # Comment out the following on additional data peers.
       DATA_PRIMARY: "true"
     stop_grace_period: 30s
     ulimits:

--- a/docker-compose/control-compose.yml
+++ b/docker-compose/control-compose.yml
@@ -3,10 +3,17 @@ version: '3.2'
 services:
   data:
     image: ns1inc/privatedns_data:${TAG:-2.1.1}
+    logging:
+      driver: "json-file"
+      options:
+        max-size: "10m"
+        max-file: "10"
     environment:        # keep environment lines if 2+ containers
-      CONFIG_PORT: 3300 # are on the host machine
+      CONFIG_PORT: 3305 # are on the host machine
       CONTAINER_NAME: ${DATA_CONTAINER_NAME:-data}
-      # DATA_PRIMARY: "true" # keep if this host will stand up as primary
+      # IMPORTANT!  This should only be enabled on a single data host.
+      # Uncomment the following on additional data peers.
+      DATA_PRIMARY: "true"
     stop_grace_period: 30s
     ulimits:
       nproc: 65535
@@ -14,9 +21,9 @@ services:
         soft: 20000
         hard: 40000
     ports:
-      - "3300:3300" # http configuration
-      - "9090:9090" # service proxy
+      - "3305:3300" # http configuration
       - "8686:8686" # metrics export
+      - "5454:5353" # replication
     sysctls:
       net.ipv6.conf.lo.disable_ipv6: 0 # enable ipv6 for loopback
     healthcheck:
@@ -33,20 +40,26 @@ services:
     command: >-
       --pop_id               ${POP_ID:-mypop}
       --server_id            ${SERVER_ID:-myserver}
-      --data_peers           ${DATA_PEERS}
+      # If running multiple data peers, uncomment the following
+      # All other data hosts (*excluding this one*) must be listed.
+      #--data_peers           ${DATA_PEERS}
       --enable_ops_metrics   true
       --expose_ops_metrics   true
   core:
     image: ns1inc/privatedns_core:${TAG:-2.1.1}
+    logging:
+      driver: "json-file"
+      options:
+        max-size: "10m"
+        max-file: "10"
     environment:        # keep environment lines if 2+ containers
       CONFIG_PORT: 3302 # are on the host machine
       CONTAINER_NAME: ${CORE_CONTAINER_NAME:-core}
-    # BOOTSTRAPPABLE: "true" # include to start a helper webserver that bootstraps the deployment for ease of use
+      BOOTSTRAPPABLE: "true" # include to start a helper webserver that bootstraps the deployment for ease of use
     restart: unless-stopped
     ports:
       - "5353:5353"     # data transport
       - "3302:3300"     # http configuration
-      - "9092:9090"     # service proxy
       - "443:443"       # https connections to portal or api
       - "80:80"         # http connections to portal or api
     healthcheck:
@@ -71,13 +84,17 @@ services:
       --enable_ops_metrics true
   xfr:
     image: ns1inc/privatedns_xfr:${TAG:-2.1.1}
+    logging:
+      driver: "json-file"
+      options:
+        max-size: "10m"
+        max-file: "10"
     environment:        # keep environment lines if 2+ containers
       CONFIG_PORT: 3303 # are on the host machine
       CONTAINER_NAME: ${XFR_CONTAINER_NAME:-xfr}
     restart: unless-stopped
     ports:
-      - "3303:3300"    # http configuration
-      - "9093:9090"    # service proxy
+      - "3303:3300"    # service proxy
       - "5400:53/udp"  # udp zone transfers
       - "5400:53/tcp"  # tcp zone transfers
     healthcheck:

--- a/docker-compose/docker-compose.yml
+++ b/docker-compose/docker-compose.yml
@@ -3,9 +3,16 @@ version: '3.2'
 services:
   data:
     image: ns1inc/privatedns_data:${TAG:-2.1.1}
+    logging:
+      driver: "json-file"
+      options:
+        max-size: "10m"
+        max-file: "10"
     environment:        # keep environment lines if 2+ containers
-      CONFIG_PORT: 3300 # are on the host machine
+      CONFIG_PORT: 3305 # are on the host machine
       CONTAINER_NAME: ${DATA_CONTAINER_NAME:-data}
+      # IMPORTANT!  This should only be enabled on a single data host.
+      # Uncomment the following on additional data peers.
       DATA_PRIMARY: "true"
     stop_grace_period: 30s
     ulimits:
@@ -14,9 +21,9 @@ services:
         soft: 20000
         hard: 40000
     ports:
-      - "3300:3300" # http configuration
-      - "9090:9090" # service proxy
+      - "3305:3300" # http configuration
       - "8686:8686" # metrics export
+      - "5454:5353" # replication
     sysctls:
       net.ipv6.conf.lo.disable_ipv6: 0 # enable ipv6 for loopback
     healthcheck:
@@ -33,19 +40,26 @@ services:
     command: >-
       --pop_id               ${POP_ID:-mypop}
       --server_id            ${SERVER_ID:-myserver}
+      # If running multiple data peers, uncomment the following
+      # All other data hosts (*excluding this one*) must be listed.
+      #--data_peers           ${DATA_PEERS}
       --enable_ops_metrics   true
       --expose_ops_metrics   true
   core:
     image: ns1inc/privatedns_core:${TAG:-2.1.1}
+    logging:
+      driver: "json-file"
+      options:
+        max-size: "10m"
+        max-file: "10"
     environment:        # keep environment lines if 2+ containers
       CONFIG_PORT: 3302 # are on the host machine
       CONTAINER_NAME: ${CORE_CONTAINER_NAME:-core}
-    # BOOTSTRAPPABLE: "true" # include to start a helper webserver that bootstraps the deployment for ease of use
+      BOOTSTRAPPABLE: "true" # include to start a helper webserver that bootstraps the deployment for ease of use
     restart: unless-stopped
     ports:
       - "5353:5353"     # data transport
       - "3302:3300"     # http configuration
-      - "9092:9090"     # service proxy
       - "443:443"       # https connections to portal or api
       - "80:80"         # http connections to portal or api
     healthcheck:
@@ -70,15 +84,19 @@ services:
       --enable_ops_metrics true
   xfr:
     image: ns1inc/privatedns_xfr:${TAG:-2.1.1}
+    logging:
+      driver: "json-file"
+      options:
+        max-size: "10m"
+        max-file: "10"
     environment:        # keep environment lines if 2+ containers
       CONFIG_PORT: 3303 # are on the host machine
       CONTAINER_NAME: ${XFR_CONTAINER_NAME:-xfr}
     restart: unless-stopped
     ports:
-      - "3303:3300"    # http configuration
-      - "9093:9090"    # service proxy
+      - "3303:3300"    # service proxy
       - "5400:53/udp"  # udp zone transfers
-      - "5400:53/tcp"      # tcp zone transfers
+      - "5400:53/tcp"  # tcp zone transfers
     healthcheck:
       test: supd health --check
       interval: 15s
@@ -97,13 +115,17 @@ services:
       --enable_ops_metrics  true
   dns:
     image: ns1inc/privatedns_dns:${TAG:-2.1.1}
+    logging:
+      driver: "json-file"
+      options:
+        max-size: "10m"
+        max-file: "10"
     environment:        # keep environment lines if 2+ containers
       CONFIG_PORT: 3301 # are on the host machine
       CONTAINER_NAME: ${DNS_CONTAINER_NAME:-dns}
     restart: unless-stopped
     ports:
       - "3301:3300" # http configuration
-      - "9091:9090" # service proxy
       - "53:53/udp" # udp port for dns
       - "53:53/tcp" # tcp port for dns
     healthcheck:
@@ -120,17 +142,27 @@ services:
     command: >-
       --pop_id              ${POP_ID:-mypop}
       --server_id           ${SERVER_ID:-myserver}
-      --core_host           ${DIST_OR_CORE_HOSTS:-dist}
+      --core_host           ${DIST_HOSTS:-dist}
       --operation_mode      ${OPERATION_MODE:-authoritative}
       --enable_ops_metrics  true
   dhcp:
     image: ns1inc/privatedns_dhcp:${TAG:-2.1.1}
+    logging:
+      driver: "json-file"
+      options:
+        max-size: "10m"
+        max-file: "10"
     environment:        # keep environment lines if 2+ containers
-      CONFIG_PORT: 3305 # are on the host machine
+      CONFIG_PORT: 3300 # are on the host machine
       CONTAINER_NAME: ${DHCP_CONTAINER_NAME:-dhcp}
     privileged: true
     restart: unless-stopped
-    network_mode: host
+    ports:
+      - "3300:3300" # http configuration
+      - "67:67/udp" # udp port for dhcp
+    # Uncomment below if this container will handle broadcast DHCP
+    # Leave commented out if it will only handle clients via relay
+    #network_mode: host
     healthcheck:
       test: supd health --check
       interval: 15s
@@ -145,10 +177,20 @@ services:
     command: >-
       --pop_id              ${POP_ID:-mypop}
       --server_id           ${SERVER_ID:-myserver}
-      --core_host           ${DIST_OR_CORE_HOSTS:-dist}
+      # Below must be changed to 'localhost' if dhcp container network mode 
+      # is host and will be on the same host as the core container.
+      --core_host           ${DIST_HOSTS:-dist}
+      # If you used the BOOTSTRAP UI to perform initial configuration, this can
+      # be left alone.  Otherwise, change this to your DHCP service definition
+      --dhcp_service_def_id 2
       --enable_ops_metrics  true
   dist:
     image: ns1inc/privatedns_dist:${TAG:-2.1.1}
+    logging:
+      driver: "json-file"
+      options:
+        max-size: "10m"
+        max-file: "10"
     environment:
       CONFIG_PORT: 3304
       CONTAINER_NAME: ${DIST_CONTAINER_NAME:-dist}
@@ -156,8 +198,6 @@ services:
     stop_grace_period: 30s
     ports:
       - "3304:3300" # http configuration
-      - "9094:9090" # service proxy
-      - "5353"      # data transport
     sysctls:
       net.ipv6.conf.lo.disable_ipv6: 0 # enable ipv6 for loopback
     healthcheck:

--- a/docker-compose/docker-compose.yml
+++ b/docker-compose/docker-compose.yml
@@ -162,7 +162,7 @@ services:
       - "67:67/udp" # udp port for dhcp
     # Uncomment below if this container will handle broadcast DHCP
     # Leave commented out if it will only handle clients via relay
-    #network_mode: host
+    # network_mode: host
     healthcheck:
       test: supd health --check
       interval: 15s
@@ -180,8 +180,9 @@ services:
       # Below must be changed to 'localhost' if dhcp container network mode 
       # is host and will be on the same host as the core container.
       --core_host           ${DIST_HOSTS:-dist}
-      # If you used the BOOTSTRAP UI to perform initial configuration, this can
-      # be left alone.  Otherwise, change this to your DHCP service definition
+      # If you used the BOOTSTRAP UI to perform initial configuration, this
+      # can be left alone.  Otherwise, change --dhcp_service_def_id to 
+      # match your DHCP service definition
       --dhcp_service_def_id 2
       --enable_ops_metrics  true
   dist:

--- a/docker-compose/edge-compose.yml
+++ b/docker-compose/edge-compose.yml
@@ -3,13 +3,17 @@ version: '3.2'
 services:
   dns:
     image: ns1inc/privatedns_dns:${TAG:-2.1.1}
+    logging:
+      driver: "json-file"
+      options:
+        max-size: "10m"
+        max-file: "10"
     environment:        # keep environment lines if 2+ containers
       CONFIG_PORT: 3301 # are on the host machine
       CONTAINER_NAME: ${DNS_CONTAINER_NAME:-dns}
     restart: unless-stopped
     ports:
       - "3301:3300" # http configuration
-      - "9091:9090" # service proxy
       - "53:53/udp" # udp port for dns
       - "53:53/tcp" # tcp port for dns
     healthcheck:
@@ -26,17 +30,27 @@ services:
     command: >-
       --pop_id              ${POP_ID:-mypop}
       --server_id           ${SERVER_ID:-myserver}
-      --core_host           ${DIST_OR_CORE_HOSTS:-dist}
+      --core_host           ${DIST_HOSTS:-dist}
       --operation_mode      ${OPERATION_MODE:-authoritative}
       --enable_ops_metrics  true
   dhcp:
     image: ns1inc/privatedns_dhcp:${TAG:-2.1.1}
+    logging:
+      driver: "json-file"
+      options:
+        max-size: "10m"
+        max-file: "10"
     environment:        # keep environment lines if 2+ containers
-      CONFIG_PORT: 3305 # are on the host machine
+      CONFIG_PORT: 3300 # are on the host machine
       CONTAINER_NAME: ${DHCP_CONTAINER_NAME:-dhcp}
     privileged: true
     restart: unless-stopped
-    network_mode: host
+    ports:
+      - "3300:3300" # http configuration
+      - "67:67/udp" # udp port for dns
+    # Uncomment below if this container will handle broadcast DHCP
+    # Leave commented out if it will only handle clients via relay
+    #network_mode: host
     healthcheck:
       test: supd health --check
       interval: 15s
@@ -51,10 +65,19 @@ services:
     command: >-
       --pop_id              ${POP_ID:-mypop}
       --server_id           ${SERVER_ID:-myserver}
-      --core_host           ${DIST_OR_CORE_HOSTS:-dist}
+      # Below must be changed to 'localhost' if container is run in 'host' mode.
+      --core_host           ${DIST_HOSTS:-dist}
+      # If you used the BOOTSTRAP UI to perform initial configuration, this can
+      # be left alone.  Otherwise, change this to your DHCP service definition ID
+      --dhcp_service_def_id 2
       --enable_ops_metrics  true
   dist:
     image: ns1inc/privatedns_dist:${TAG:-2.1.1}
+    logging:
+      driver: "json-file"
+      options:
+        max-size: "10m"
+        max-file: "10"
     environment:
       CONFIG_PORT: 3304
       CONTAINER_NAME: ${DIST_CONTAINER_NAME:-dist}
@@ -62,8 +85,6 @@ services:
     stop_grace_period: 30s
     ports:
       - "3304:3300" # http configuration
-      - "9094:9090" # service proxy
-      - "5353"      # data transport
     sysctls:
       net.ipv6.conf.lo.disable_ipv6: 0 # enable ipv6 for loopback
     healthcheck:

--- a/docker-compose/edge-compose.yml
+++ b/docker-compose/edge-compose.yml
@@ -50,7 +50,7 @@ services:
       - "67:67/udp" # udp port for dhcp
     # Uncomment below if this container will handle broadcast DHCP
     # Leave commented out if it will only handle clients via relay
-    #network_mode: host
+    # network_mode: host
     healthcheck:
       test: supd health --check
       interval: 15s

--- a/docker-compose/edge-compose.yml
+++ b/docker-compose/edge-compose.yml
@@ -102,7 +102,7 @@ services:
       --pop_id               ${POP_ID:-mypop}
       --server_id            ${SERVER_ID:-myserver}
       # This value must be set to the IP address of your control node
-      # (i.e. the server that hosts the core container
+      # (i.e. the server that hosts the core container)
       --core_host            ${CORE_HOSTS}
       --enable_ops_metrics   true
 networks:

--- a/docker-compose/edge-compose.yml
+++ b/docker-compose/edge-compose.yml
@@ -47,7 +47,7 @@ services:
     restart: unless-stopped
     ports:
       - "3300:3300" # http configuration
-      - "67:67/udp" # udp port for dns
+      - "67:67/udp" # udp port for dhcp
     # Uncomment below if this container will handle broadcast DHCP
     # Leave commented out if it will only handle clients via relay
     #network_mode: host
@@ -101,7 +101,9 @@ services:
     command: >-
       --pop_id               ${POP_ID:-mypop}
       --server_id            ${SERVER_ID:-myserver}
-      --core_host            ${CORE_HOSTS:-core}
+      # This value must be set to the IP address of your control node
+      # (i.e. the server that hosts the core container
+      --core_host            ${CORE_HOSTS}
       --enable_ops_metrics   true
 networks:
   default:


### PR DESCRIPTION
Changes include...

- Move dhcp container from "host" mode back to "net" mode.  This means that by default dhcp will not _by default_ respond to broadcast DHCPDISCOVER's, however I believe this solves more problems than it creates.  Most scenarios we see are users testing on their laptops (Mac and Windows do not support host mode), or POC's in labs in which DHCP requests are coming in as unicast from helpers/relays.  The compose files are adjusted and documented such that switching to "host" mode is just a matter of changing/uncommenting two lines.

- Swap default ports between dhcp and data container.  This allows the dhcp container to run in "host" mode without conflicting with the web config port of the data container, which was previously causing haproxy to fail to start on the dhcp container in single host scearios.

- Add default log rotation to every container

- Other various minor tweaks to control/edge files to make them more useful without modification.