### PR TITLE
Parameterize data transport port

### DIFF
--- a/terraform/modules/core/main.tf
+++ b/terraform/modules/core/main.tf
@@ -22,7 +22,7 @@ provider "docker" {
     for_each = var.docker_registry_address != null ? list(var.docker_registry_address) : []
     iterator = address
     content {
-      address = address.value
+      address  = address.value
       username = var.docker_registry_username
       password = var.docker_registry_password
     }
@@ -31,14 +31,14 @@ provider "docker" {
 
 data "docker_registry_image" "core" {
   count = var.docker_registry_address != null ? 1 : 0
-  name = local.docker_image_name
+  name  = local.docker_image_name
 }
 
 resource "docker_image" "core" {
-  count = var.docker_registry_address != null ? 1 : 0
-  name = data.docker_registry_image.core[count.index].name
+  count         = var.docker_registry_address != null ? 1 : 0
+  name          = data.docker_registry_image.core[count.index].name
   pull_triggers = [data.docker_registry_image.core[count.index].sha256_digest]
-  keep_locally = true
+  keep_locally  = true
 }
 
 resource "docker_volume" "core" {
@@ -77,9 +77,13 @@ resource "docker_container" "core" {
   }
 
   # data transport
-  ports {
-    internal = 5353
-    external = 5353
+  dynamic "ports" {
+    for_each = var.data_port != null ? list(var.data_port) : []
+    iterator = data_port
+    content {
+      internal = 5353
+      external = data_port.value
+    }
   }
 
   # service proxy
@@ -89,14 +93,14 @@ resource "docker_container" "core" {
   }
 
   healthcheck {
-    test = ["CMD", "supd", "health"]
+    test     = ["CMD", "supd", "health"]
     interval = "15s"
-    timeout = "10s"
-    retries = 3
+    timeout  = "10s"
+    retries  = 3
   }
 
   volumes {
-    volume_name = docker_volume.core.name
+    volume_name    = docker_volume.core.name
     container_path = "/ns1/data"
   }
 

--- a/terraform/modules/core/variables.tf
+++ b/terraform/modules/core/variables.tf
@@ -97,3 +97,8 @@ variable "docker_log_driver" {
   default     = "json-file"
   description = "Docker log driver to use, see https://docs.docker.com/config/containers/logging/configure/"
 }
+
+variable "data_port" {
+  default     = 5353
+  description = "Port number to expose for external data transport.  Set to null to disable exposing this port."
+}

--- a/terraform/modules/core/variables.tf
+++ b/terraform/modules/core/variables.tf
@@ -100,5 +100,5 @@ variable "docker_log_driver" {
 
 variable "data_port" {
   default     = 5353
-  description = "Port number to expose for external data transport.  Set to null to disable exposing this port."
+  description = "Port exposed out of the container for data transport.  Setting value to null disables exposing this port."
 }

--- a/terraform/modules/data/main.tf
+++ b/terraform/modules/data/main.tf
@@ -113,11 +113,14 @@ resource "docker_container" "data" {
     external = 3300
   }
 
+  # data transport
+  # should only be exposed if cluster_id is configured and data_port was not disabled
   dynamic "ports" {
-    for_each = var.cluster_id != null ? list(var.cluster_id) : []
+    for_each = var.cluster_id != null && var.data_port != null ? list(var.data_port) : []
+    iterator = data_port
     content {
       internal = 5353
-      external = 5353
+      external = data_port.value
     }
   }
 

--- a/terraform/modules/data/variables.tf
+++ b/terraform/modules/data/variables.tf
@@ -105,5 +105,5 @@ variable "docker_log_driver" {
 
 variable "data_port" {
   default     = 5353
-  description = "Port number to expose for external data transport.  Set to null to disable exposing this port."
+  description = "Port exposed out of the container for data transport.  Setting value to null disables exposing this port."
 }

--- a/terraform/modules/data/variables.tf
+++ b/terraform/modules/data/variables.tf
@@ -63,13 +63,13 @@ variable "enable_ops_metrics" {
 }
 
 variable "telegraf_output_elasticsearch_data_host" {
-  default      = null
-  description  = "The elasticsearch host to export metrics"
+  default     = null
+  description = "The elasticsearch host to export metrics"
 }
 
 variable "telegraf_output_elasticsearch_index" {
-  default      = null
-  description  = "The elasticsearch index to use when exporting metrics"
+  default     = null
+  description = "The elasticsearch index to use when exporting metrics"
 }
 
 variable "expose_ops_metrics" {
@@ -101,4 +101,9 @@ variable "hostname" {
 variable "docker_log_driver" {
   default     = "json-file"
   description = "Docker log driver to use, see https://docs.docker.com/config/containers/logging/configure/"
+}
+
+variable "data_port" {
+  default     = 5353
+  description = "Port number to expose for external data transport.  Set to null to disable exposing this port."
 }

--- a/terraform/modules/dist/main.tf
+++ b/terraform/modules/dist/main.tf
@@ -60,12 +60,13 @@ resource "docker_container" "dist" {
   }
 
   # data transport
-  ports {
-    internal = 5353
-    external = 5353
-    # can we map this to 5353?
-    # how do we switch to ephemeral if on same host
-    # as core?
+  dynamic "ports" {
+    for_each = var.data_port != null ? list(var.data_port) : []
+    iterator = data_port
+    content {
+      internal = 5353
+      external = data_port.value
+    }
   }
 
   # service proxy

--- a/terraform/modules/dist/variables.tf
+++ b/terraform/modules/dist/variables.tf
@@ -74,5 +74,5 @@ variable "docker_log_driver" {
 
 variable "data_port" {
   default     = 5353
-  description = "Port number to expose for external data transport.  Set to null to disable exposing this port."
+  description = "Port exposed out of the container for data transport.  Setting value to null disables exposing this port."
 }

--- a/terraform/modules/dist/variables.tf
+++ b/terraform/modules/dist/variables.tf
@@ -71,3 +71,8 @@ variable "docker_log_driver" {
   default     = "json-file"
   description = "Docker log driver to use, see https://docs.docker.com/config/containers/logging/configure/"
 }
+
+variable "data_port" {
+  default     = 5353
+  description = "Port number to expose for external data transport.  Set to null to disable exposing this port."
+}


### PR DESCRIPTION
Adds vars to core, data and dist to make exposed port number for data transport port configurable.

Will be exposed as `5353` by default on all containers to match current behaviour, but can be customized per module by configuring `data_port` var.  If set as `data_port = null`, data transport port will not be exposed at all.

Also includes some linting changes.