### PR TITLE
Compose file enhancements

### DIFF
--- a/docker-compose/control-compose.yml
+++ b/docker-compose/control-compose.yml
@@ -1,5 +1,5 @@
 ---
-version: '3.2'
+version: '3.4'
 services:
   data:
     image: ns1inc/privatedns_data:${TAG:-2.5.3}
@@ -31,6 +31,7 @@ services:
       interval: 15s
       timeout: 10s
       retries: 3
+      start_period: 120s
     volumes:
       - type: volume
         source: ns1data
@@ -76,6 +77,7 @@ services:
       interval: 15s
       timeout: 10s
       retries: 3
+      start_period: 120s
     volumes:
       - type: volume
         source: ns1core
@@ -111,6 +113,7 @@ services:
       interval: 15s
       timeout: 10s
       retries: 3
+      start_period: 120s
     volumes:
       - type: volume
         source: ns1xfr

--- a/docker-compose/docker-compose.yml
+++ b/docker-compose/docker-compose.yml
@@ -1,5 +1,5 @@
 ---
-version: '3.2'
+version: '3.4'
 services:
   data:
     image: ns1inc/privatedns_data:${TAG:-2.5.3}
@@ -32,6 +32,7 @@ services:
       interval: 15s
       timeout: 10s
       retries: 3
+      start_period: 120s
     volumes:
       - type: volume
         source: ns1data
@@ -64,6 +65,7 @@ services:
       interval: 15s
       timeout: 10s
       retries: 3
+      start_period: 120s
     volumes:
       - type: volume
         source: ns1core
@@ -99,6 +101,7 @@ services:
       interval: 15s
       timeout: 10s
       retries: 3
+      start_period: 120s
     volumes:
       - type: volume
         source: ns1xfr
@@ -130,6 +133,7 @@ services:
       interval: 15s
       timeout: 10s
       retries: 3
+      start_period: 120s
     volumes:
       - type: volume
         source: ns1dns
@@ -165,6 +169,7 @@ services:
       interval: 15s
       timeout: 10s
       retries: 3
+      start_period: 120s
     volumes:
       - type: volume
         source: ns1dhcp
@@ -202,6 +207,7 @@ services:
       interval: 15s
       timeout: 10s
       retries: 3
+      start_period: 120s
     volumes:
       - type: volume
         source: ns1dist

--- a/docker-compose/docker-compose.yml
+++ b/docker-compose/docker-compose.yml
@@ -14,6 +14,7 @@ services:
       # IMPORTANT!  DATA_PRIMARY should only be enabled on a single data host.
       # Comment out the following on additional data peers.
       DATA_PRIMARY: "true"
+    restart: unless-stopped
     stop_grace_period: 30s
     ulimits:
       nproc: 65535

--- a/docker-compose/edge-compose.yml
+++ b/docker-compose/edge-compose.yml
@@ -1,5 +1,5 @@
 ---
-version: '3.2'
+version: '3.4'
 services:
   dns:
     image: ns1inc/privatedns_dns:${TAG:-2.5.3}
@@ -21,6 +21,7 @@ services:
       interval: 15s
       timeout: 10s
       retries: 3
+      start_period: 120s
     volumes:
       - type: volume
         source: ns1dns
@@ -56,6 +57,7 @@ services:
       interval: 15s
       timeout: 10s
       retries: 3
+      start_period: 120s
     volumes:
       - type: volume
         source: ns1dhcp
@@ -93,6 +95,7 @@ services:
       interval: 15s
       timeout: 10s
       retries: 3
+      start_period: 120s
     volumes:
       - type: volume
         source: ns1dist

--- a/docker-compose/monitoring-compose.yml
+++ b/docker-compose/monitoring-compose.yml
@@ -226,7 +226,7 @@ services:
     ports:
       - "3308:3300" # http configuration
     healthcheck:
-      test: supd health --check
+      test: supd health 
       interval: 15s
       timeout: 10s
       retries: 3

--- a/docker-compose/monitoring-compose.yml
+++ b/docker-compose/monitoring-compose.yml
@@ -1,5 +1,5 @@
 ---
-version: '3.2'
+version: '3.4'
 services:
   data:
     image: ns1inc/privatedns_data:${TAG:-2.5.3}
@@ -31,6 +31,7 @@ services:
       interval: 15s
       timeout: 10s
       retries: 3
+      start_period: 120s
     volumes:
       - type: volume
         source: ns1data
@@ -63,6 +64,7 @@ services:
       interval: 15s
       timeout: 10s
       retries: 3
+      start_period: 120s
     volumes:
       - type: volume
         source: ns1core
@@ -98,6 +100,7 @@ services:
       interval: 15s
       timeout: 10s
       retries: 3
+      start_period: 120s
     volumes:
       - type: volume
         source: ns1xfr
@@ -129,6 +132,7 @@ services:
       interval: 15s
       timeout: 10s
       retries: 3
+      start_period: 120s
     volumes:
       - type: volume
         source: ns1dns
@@ -164,6 +168,7 @@ services:
       interval: 15s
       timeout: 10s
       retries: 3
+      start_period: 120s
     volumes:
       - type: volume
         source: ns1dhcp
@@ -201,6 +206,7 @@ services:
       interval: 15s
       timeout: 10s
       retries: 3
+      start_period: 120s
     volumes:
       - type: volume
         source: ns1dist
@@ -230,6 +236,7 @@ services:
       interval: 15s
       timeout: 10s
       retries: 3
+      start_period: 120s
     volumes:
       - type: volume
         source: ns1monitoringedge

--- a/docker-compose/monitoring-compose.yml
+++ b/docker-compose/monitoring-compose.yml
@@ -14,6 +14,7 @@ services:
       # IMPORTANT!  DATA_PRIMARY should only be enabled on a single data host.
       # Comment out the following on additional data peers.
       DATA_PRIMARY: "true"
+    restart: unless-stopped
     stop_grace_period: 30s
     ulimits:
       nproc: 65535


### PR DESCRIPTION
- Remove any references to deprecated `--check` flag
- Add `restart: unless-stopped` to single host data
- Add `start_period` parameter to the health checks so that docker waits up to 2 minutes prior to reporting a service as being unhealthy. This also required us to bump our compose version from 3.2 to 3.4