### PR TITLE
bootstrap users shouldn't have zone restrictions

### DIFF
--- a/helm/files/bootstrap.py
+++ b/helm/files/bootstrap.py
@@ -174,7 +174,7 @@ class BootstrapManager(object):
                         "manage_account_settings": True,
                     },
                     "dns": {
-                        "zones_allow": ["example.com"],
+                        "zones_allow": [],
                         "zones_deny": [],
                         "zones_allow_by_default": True,
                         "manage_zones": True,
@@ -225,7 +225,8 @@ class BootstrapManager(object):
                         "manage_account_settings": True,
                     },
                     "dns": {
-                        "zones_allow": ["example.com"],
+                        "zones_allow": [],
+                        "zones_deny": [],
                         "zones_allow_by_default": True,
                         "manage_zones": True,
                         "view_zones": True,


### PR DESCRIPTION
even ones that don't actually do anything can trigger "user has zone
restrictions, should they be allow to do X?" checks.