### PR TITLE
Remove Influx ports from compose files

### DIFF
--- a/docker-compose/control-compose.yml
+++ b/docker-compose/control-compose.yml
@@ -27,7 +27,6 @@ services:
     shm_size: ${DATA_SHARED_MEM:-2gb}
     ports:
       - "3305:3300" # http configuration
-      - "8686:8686" # metrics export
       - "5454:5353" # replication
     sysctls:
       net.ipv6.conf.lo.disable_ipv6: 0 # enable ipv6 for loopback

--- a/docker-compose/docker-compose.yml
+++ b/docker-compose/docker-compose.yml
@@ -28,7 +28,6 @@ services:
     shm_size: ${DATA_SHARED_MEM:-2gb}
     ports:
       - "3305:3300" # http configuration
-      - "8686:8686" # metrics export
       - "5454:5353" # replication
     sysctls:
       net.ipv6.conf.lo.disable_ipv6: 0 # enable ipv6 for loopback


### PR DESCRIPTION
We no longer ship with Influx, so port 8686 hasn't been necessary since pre-3.0